### PR TITLE
Allow any attribute name if there is only one attribute 

### DIFF
--- a/com.ibm.streamsx.json/impl/java/src/com/ibm/streamsx/json/JSONToTuple.java
+++ b/com.ibm.streamsx.json/impl/java/src/com/ibm/streamsx/json/JSONToTuple.java
@@ -52,7 +52,8 @@ import com.ibm.streams.operator.types.Timestamp;
 @PrimitiveOperator(name="JSONToTuple", description=JSONToTuple.DESC)
 public class JSONToTuple extends AbstractOperator  
 {
-	private String jsonStringAttribute = "jsonString";
+	private String jsonStringAttribute = null;
+	private static final String defaultJsonStringAttribute = "jsonString";
 	private Logger l = Logger.getLogger(JSONToTuple.class.getCanonicalName());
 	boolean ignoreParsingError = false;
 	private String jsonStringOutputAttribute = null;
@@ -109,6 +110,14 @@ public class JSONToTuple extends AbstractOperator
 		hasOptionalOut = op.getStreamingOutputs().size() > 1;
 
 		List<MetaType> types  = Arrays.asList(MetaType.RSTRING, MetaType.USTRING);
+		if (jsonStringAttribute == null) {
+			if (ssIp0.getAttributeCount() == 1) {
+				jsonStringAttribute = ssIp0.getAttribute(0).getName();
+			}
+			else {
+				jsonStringAttribute = defaultJsonStringAttribute;
+			}
+		}
 		verifyAttributeType(op,  ssIp0, jsonStringAttribute, types).getMetaType();
 
 		if(jsonStringOutputAttribute!=null) {

--- a/com.ibm.streamsx.json/impl/java/src/com/ibm/streamsx/json/TupleToJSON.java
+++ b/com.ibm.streamsx.json/impl/java/src/com/ibm/streamsx/json/TupleToJSON.java
@@ -36,7 +36,8 @@ import com.ibm.streams.operator.model.PrimitiveOperator;
 @PrimitiveOperator(name="TupleToJSON", description=TupleToJSON.DESC)
 public class TupleToJSON extends AbstractOperator {
 
-	private String jsonStringAttribute = "jsonString";
+	private String jsonStringAttribute = null;
+	private static final String defaultJsonStringAttribute = "jsonString";
 
 	private String rootAttribute = null;
 	private Type rootAttributeType =null;
@@ -60,7 +61,17 @@ public class TupleToJSON extends AbstractOperator {
 		super.initialize(op);
 
 		StreamSchema ssop = getOutput(0).getStreamSchema();
-
+		if (jsonStringAttribute == null) {
+			// If we haven't set it using an argument, then...
+			if (ssop.getAttributeCount() > 1) {
+				// when there's more than one attribute, use the default jsonString
+				jsonStringAttribute = defaultJsonStringAttribute;
+			}
+			else {
+				// Only one attribute; so it's clear what to use.
+				jsonStringAttribute = ssop.getAttribute(0).getName();
+			}
+		}
 		JSONToTuple.verifyAttributeType(getOperatorContext(), ssop, jsonStringAttribute, 
 				Arrays.asList(MetaType.RSTRING, MetaType.USTRING));
 


### PR DESCRIPTION
Relates to IBMStreams/streamsx.json #21.

Currently, even when there's only one input attribute for JSONToTuple, the name must be specified or JSONString.  Likewise, when there's only one output attribute for TupleToJson, the name must be specified or JSONString.  This change let's the attribute name be unspecified in those cases. 
