### PR TITLE
Add parameters of type attribute when appropriate.

### DIFF
--- a/com.ibm.streamsx.json/impl/java/src/com/ibm/streamsx/json/TupleToJSON.java
+++ b/com.ibm.streamsx.json/impl/java/src/com/ibm/streamsx/json/TupleToJSON.java
@@ -19,6 +19,7 @@ import com.ibm.streams.operator.StreamSchema;
 import com.ibm.streams.operator.StreamingInput;
 import com.ibm.streams.operator.StreamingOutput;
 import com.ibm.streams.operator.Tuple;
+import com.ibm.streams.operator.TupleAttribute;
 import com.ibm.streams.operator.Type;
 import com.ibm.streams.operator.Type.MetaType;
 import com.ibm.streams.operator.encoding.EncodingFactory;
@@ -38,13 +39,20 @@ public class TupleToJSON extends AbstractOperator {
 
 	private String jsonStringAttribute = null;
 	private static final String defaultJsonStringAttribute = "jsonString";
-
+	private static final String ROOT_ATTRIBUTE_PARAM = "inputAttribute";
+	TupleAttribute<Tuple,?> rootAttr = null;
 	private String rootAttribute = null;
 	private Type rootAttributeType =null;
 
 	private static Logger l = Logger.getLogger(TupleToJSON.class.getCanonicalName());
 
-
+	@Parameter(name=ROOT_ATTRIBUTE_PARAM,
+			optional = true,
+			description="Input stream attribute  to be used as the root of the JSON object.  Default is the input tuple.  This parameter specfies the attribute, not its name.")
+	public void setRoot(TupleAttribute<Tuple,?> in) {
+		rootAttr = in;
+	}
+	
 	@Parameter(optional=true, 
 			description="Name of the output stream attribute where the JSON string will be populated. Default is jsonString")
 	public void setJsonStringAttribute(String value) {
@@ -76,6 +84,11 @@ public class TupleToJSON extends AbstractOperator {
 				Arrays.asList(MetaType.RSTRING, MetaType.USTRING));
 
 		StreamSchema ssip = getInput(0).getStreamSchema();
+	
+		if (rootAttr != null) {
+			rootAttribute = rootAttr.getAttribute().getName();
+		}
+		
 		if(rootAttribute!=null) {
 			rootAttributeType = JSONToTuple.verifyAttributeType(getOperatorContext(), ssip, rootAttribute, 
 					Arrays.asList(MetaType.TUPLE, MetaType.LIST, MetaType.BLIST, MetaType.SET, MetaType.BSET));

--- a/com.ibm.streamsx.json/info.xml
+++ b/com.ibm.streamsx.json/info.xml
@@ -9,8 +9,8 @@
   <info:identity>
     <info:name>com.ibm.streamsx.json</info:name>
     <info:description></info:description>
-    <info:version>1.0.0.__dev__</info:version>
-    <info:requiredProductVersion>3.2</info:requiredProductVersion>
+    <info:version>1.1.0.__dev__</info:version>
+    <info:requiredProductVersion>4.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies/>
 </info:toolkitInfoModel>

--- a/samples/TupleToJSONConvert/com.ibm.streamsx.json.sample.ttoj/JsonArrayConvert.spl
+++ b/samples/TupleToJSONConvert/com.ibm.streamsx.json.sample.ttoj/JsonArrayConvert.spl
@@ -29,7 +29,7 @@ composite JsonArrayConvert {
 		stream<rstring jsonString> OutputS = com.ibm.streamsx.json::TupleToJSON(InputS) {
 			param
 				//this attribute must be specified
-				rootAttribute : "mylist";
+				inputAttribute :mylist;
 		}
 		() as SinkOp = Custom(OutputS) {
 			logic onTuple OutputS : {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,12 +10,12 @@ args=-t ../com.ibm.streamsx.json
 ns=com.ibm.streamsx.json.tests
 outputdir=./output
 
-tests=BasicTest ListTest SetOfListTest
+tests=BasicTest ListTest SetOfListTest InputSpecificationTest RootAttributeTest
 
 rntest=./scripts/testRunner.sh
 ftest=./scripts/expectFail.sh
 
-all: BasicTest ListTest SetOfListTest NullBasicTest RecordArrayListTest CompileFailtest
+all: BasicTest ListTest SetOfListTest NullBasicTest RecordArrayListTest InputSpecificationTest RootAttributeTest CompileFailtest
 	@echo "Tests Passed"
 
 compile: ${tests}

--- a/tests/com.ibm.streamsx.json.tests/InputSpecification.spl
+++ b/tests/com.ibm.streamsx.json.tests/InputSpecification.spl
@@ -1,0 +1,74 @@
+
+namespace com.ibm.streamsx.json.tests;
+
+use com.ibm.streamsx.json::JSONToTuple;
+type InputTestType = rstring name, int32 age;
+
+composite InputSpecificationTest  {
+
+graph
+
+stream<rstring theString>  SingleAttribute = Beacon() {
+param iterations: 10;
+output SingleAttribute:
+    theString = "{\"name\":\"Buffy\", \"age\":"+(rstring)IterationCount()+"}";
+
+}
+
+stream<int32 count,rstring jsonString> MultiAttribute = Functor(SingleAttribute) {
+   logic state: {
+    mutable int32 iter = 0;
+   }
+   output MultiAttribute:
+        count = iter++,
+        jsonString = theString;
+}
+
+stream<int32 count, rstring theString> NeedArg = Functor(SingleAttribute) {
+logic state: {mutable int32 iter=0;}
+output NeedArg:
+    count = iter++;
+}
+
+// Single attribute, no need to specify.
+stream<InputTestType> SingleAttrTup = JSONToTuple(SingleAttribute) {
+
+}
+
+
+stream<InputTestType> OldWay = JSONToTuple(NeedArg) {
+    param jsonStringAttribute: "theString";
+}
+
+
+stream<InputTestType> NewWay = JSONToTuple(NeedArg) {
+    param inputAttribute: theString;
+}
+
+() as checker = Custom(OldWay;NewWay) {
+logic state: {
+    mutable list<InputTestType> oldWay = (list<InputTestType>)[];
+    mutable list<InputTestType> newWay = (list<InputTestType>)[];
+    mutable int32 numPunct = 0;
+}
+onTuple OldWay:
+    appendM(oldWay,OldWay);
+onTuple NewWay:
+    appendM(newWay,NewWay);
+onPunct OldWay:
+    if (currentPunct() == Sys.FinalMarker) {
+        numPunct++;
+        if (numPunct == 2) {
+            assert(oldWay == newWay);
+        }
+    }
+onPunct NewWay:
+    if (currentPunct() == Sys.FinalMarker) {
+        numPunct++;
+        if (numPunct == 2) {
+            assert(oldWay == newWay);
+        }
+    }
+}
+
+}

--- a/tests/com.ibm.streamsx.json.tests/RootAttribute.spl
+++ b/tests/com.ibm.streamsx.json.tests/RootAttribute.spl
@@ -1,0 +1,74 @@
+namespace com.ibm.streamsx.json.tests;
+
+use com.ibm.streamsx.json::TupleToJSON;
+
+composite AssertEqual(input Stream1, Stream2) {
+
+graph
+() as checker = Custom(Stream1;Stream2) {
+
+logic state: {
+    mutable list<Stream1> listOne;
+    mutable list<Stream2> listTwo;
+    mutable int32 numPunct = 0;
+}
+onTuple Stream1:
+    appendM(listOne,Stream1);
+onTuple Stream2:
+    appendM(listTwo,Stream2);
+onPunct Stream1: 
+    if (currentPunct() == Sys.FinalMarker) {
+        numPunct++;
+        assert(numPunct<1 || listOne == listTwo);
+    }
+onPunct Stream2:
+    if (currentPunct() == Sys.FinalMarker) {
+        numPunct++;
+        assert(numPunct<1 || listOne == listTwo);
+    }
+}
+
+}
+
+composite RootAttributeTest {
+
+graph
+
+
+stream<list<rstring> characters, tuple<rstring author, rstring title> origin> Data = Beacon() {
+param iterations: 1;
+
+output Data:
+    characters = ["Ajax","Achilles","Agamemon","Helen","Paris"],
+    origin = {author="Homer",title="The Iliad"};
+}
+
+stream<rstring jsonString> WholeTuple = TupleToJSON(Data) {
+
+}
+
+stream<rstring jsonString> List1 = TupleToJSON(Data) {
+    param rootAttribute: "characters";
+}
+
+() as checkList = AssertEqual(List1;List2) {
+
+}
+
+stream<rstring jsonString> List2 = TupleToJSON(Data) {
+    param inputAttribute: characters;
+}
+
+stream<rstring jsonString> Tuple1 = TupleToJSON(Data) {
+    param rootAttribute: "origin";
+}
+
+stream<rstring jsonString> Tuple2 = TupleToJSON(Data) {
+    param inputAttribute: origin;
+}
+
+() as checkTuple = AssertEqual(Tuple1;Tuple2) {
+
+}
+
+}

--- a/tests/com.ibm.streamsx.json.tests/Verfier.spl
+++ b/tests/com.ibm.streamsx.json.tests/Verfier.spl
@@ -138,6 +138,7 @@ composite VerifierArray(input InputS) {
 		param
 			rootAttribute : $listAttr;
 		}
+
 		stream<MyType> OutputS = 
 			com.ibm.streamsx.json::JSONToTuple(JsonS)
 		{


### PR DESCRIPTION
Fixes IBMStreams/streamsx.json #33 

Add parameters of type attribute that can be used instead of the parameters of type rstring that refer to the parameter name.