### PR TITLE
Mark C++ functions in header as inline to allow fusing of operators invoking functions.

### DIFF
--- a/com.ibm.streamsx.json/impl/include/Json.h
+++ b/com.ibm.streamsx.json/impl/include/Json.h
@@ -22,13 +22,13 @@ using namespace SPL;
 namespace com { namespace ibm { namespace streamsx { namespace json {
 
 	template<typename String>
-	char const* convToChars(String const& str) { return str.c_str(); }
+	inline char const* convToChars(String const& str) { return str.c_str(); }
 
 	template<>
-	char const* convToChars<ustring>(ustring const& str) { return spl_cast<rstring,ustring>::cast(str).c_str(); }
+	inline char const* convToChars<ustring>(ustring const& str) { return spl_cast<rstring,ustring>::cast(str).c_str(); }
 
 	template<>
-	char const* convToChars<ConstValueHandle>(const ConstValueHandle& valueHandle) {
+	inline char const* convToChars<ConstValueHandle>(const ConstValueHandle& valueHandle) {
 		switch(valueHandle.getMetaType()) {
 			case Meta::Type::BSTRING : {
 				const BString & str = valueHandle;
@@ -46,17 +46,17 @@ namespace com { namespace ibm { namespace streamsx { namespace json {
 	}
 
 	template<typename Container, typename Iterator>
-	void writeArray(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle);
+	inline void writeArray(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle);
 
 	template<typename Container, typename Iterator>
-	void writeMap(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle);
+	inline void writeMap(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle);
 
-	void writeTuple(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle);
+	inline void writeTuple(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle);
 
-	void writePrimitive(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle);
+	inline void writePrimitive(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle);
 
 
-	void writeAny(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle) {
+	inline void writeAny(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle) {
 
 		switch (valueHandle.getMetaType()) {
 			case Meta::Type::LIST : {
@@ -92,7 +92,7 @@ namespace com { namespace ibm { namespace streamsx { namespace json {
 	}
 
 	template<typename Container, typename Iterator>
-	void writeArray(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle) {
+	inline void writeArray(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle) {
 
 		writer.StartArray();
 
@@ -107,7 +107,7 @@ namespace com { namespace ibm { namespace streamsx { namespace json {
 	}
 
 	template<typename Container, typename Iterator>
-	void writeMap(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle) {
+	inline void writeMap(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle) {
 
 		writer.StartObject();
 
@@ -124,7 +124,7 @@ namespace com { namespace ibm { namespace streamsx { namespace json {
 		writer.EndObject();
 	}
 
-	void writeTuple(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle) {
+	inline void writeTuple(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle) {
 
 		writer.StartObject();
 
@@ -141,7 +141,7 @@ namespace com { namespace ibm { namespace streamsx { namespace json {
 		writer.EndObject();
 	}
 
-	void writePrimitive(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle) {
+	inline void writePrimitive(Writer<StringBuffer> & writer, ConstValueHandle const & valueHandle) {
 
 		switch (valueHandle.getMetaType()) {
 			case Meta::Type::BOOLEAN : {

--- a/com.ibm.streamsx.json/info.xml
+++ b/com.ibm.streamsx.json/info.xml
@@ -27,7 +27,7 @@ resulting stream using `com.ibm.streamsx.topology.topic::Publish`.
 An application implemented in Python (or any other language) may
 them subscribe to the stream of JSON objects.
 </info:description>
-    <info:version>1.2.1.__dev__</info:version>
+    <info:version>1.2.2.__dev__</info:version>
     <info:requiredProductVersion>4.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies/>

--- a/test/build.xml
+++ b/test/build.xml
@@ -41,6 +41,16 @@
     </javac>
   </target>
 
+  <target name="compile-spl-test-code">
+     <delete dir="testtk/output"/>
+     <exec executable="${streams.install}/bin/sc" dir="testtk" failonerror="yes">
+        <arg value="-M"/>
+        <arg value="FuseJson68"/>
+        <arg value="-t"/>
+        <arg value="${toolkit}"/>
+     </exec>
+  </target>
+
   <!-- ensure all the samples can be built -->
   <target name="compile-samples">
      <exec executable="${streams.install}/bin/sc" dir="../samples/JSONToTupleConvert" failonerror="yes">
@@ -79,7 +89,7 @@
      </exec>
   </target>
 
-  <target name="test" depends="compile-tests,compile-samples">
+  <target name="test" depends="compile-tests,compile-spl-test-code,compile-samples">
     <junit printsummary="yes" fork="yes" haltonfailure="yes">
       <classpath>
         <path refid="cp.streams" />

--- a/test/testtk/fuse68.spl
+++ b/test/testtk/fuse68.spl
@@ -1,0 +1,12 @@
+use com.ibm.streamsx.json::toJSON;
+
+public composite FuseJson68 {
+   graph
+     () as A = Custom() {
+      logic state: rstring a = toJSON("a", 3) + toJSON("b", "4");
+     }
+     () as B = Custom() {
+      logic state: rstring a = toJSON("a", true) + toJSON("b", "4");
+     }
+   config placement: partitionColocation("AB");
+}


### PR DESCRIPTION
Fixes #68 

Added test which failed to compile prior to 6cbdf903bb93175eb15cdcc2f1d913dc179380d9
